### PR TITLE
fix(FEC-8328): send load event only on media loaded

### DIFF
--- a/src/ott-analytics.js
+++ b/src/ott-analytics.js
@@ -23,7 +23,9 @@ export default class OttAnalytics extends BasePlugin {
    */
   static defaultConfig: Object = {
     mediaHitInterval: 30,
-    startTime: null
+    startTime: null,
+    disableMediaHit: false,
+    disableMediaMark: false
   };
 
   /**
@@ -199,13 +201,15 @@ export default class OttAnalytics extends BasePlugin {
    * @returns {void}
    */
   _sendAnalytics(action: string, params: Object): void {
-    if (!this._validate()) {
+    if (!this._validate(action === OttAnalyticsEvent.HIT)) {
       return;
     }
     const playerData: Object = {
       action: action,
-      averageBitrate: 0, totalBitrate: 0,
-      currentBitrate: 0, fileId: params.fileId,
+      averageBitrate: 0,
+      totalBitrate: 0,
+      currentBitrate: 0,
+      fileId: params.fileId,
     };
     const bookMark: Object = {
       type: params.mediaType,
@@ -226,7 +230,15 @@ export default class OttAnalytics extends BasePlugin {
       });
   }
 
-  _validate(): boolean {
+  _validate(isMediaHit: boolean): boolean {
+    if (isMediaHit && this.config.disableMediaHit) {
+      this.logger.info(`block MediaHit report`);
+      return false;
+    }
+    if (!isMediaHit && this.config.disableMediaMark) {
+      this.logger.info(`block MediaMark report`);
+      return false;
+    }
     if (!this.config.ks) {
       this._logMissingParam('ks');
       return false;

--- a/src/ott-analytics.js
+++ b/src/ott-analytics.js
@@ -199,6 +199,9 @@ export default class OttAnalytics extends BasePlugin {
    * @returns {void}
    */
   _sendAnalytics(action: string, params: Object): void {
+    if (!this._validate()) {
+      return;
+    }
     const playerData: Object = {
       action: action,
       averageBitrate: 0, totalBitrate: 0,
@@ -223,6 +226,13 @@ export default class OttAnalytics extends BasePlugin {
       });
   }
 
+  _validate(): boolean {
+    if (!this.config.ks) {
+      this._logMissingParam('ks');
+      return false;
+    }
+    return true;
+  }
   /**
    * Starts the media hit interval.
    * @private

--- a/src/ott-analytics.js
+++ b/src/ott-analytics.js
@@ -38,14 +38,12 @@ export default class OttAnalytics extends BasePlugin {
     return true;
   }
 
-  _isPlaying: boolean;
-  _concurrentFlag: boolean;
-  _fileId: number;
-  _didFirstPlay: boolean;
-  _mediaHitInterval: number;
-  _continueTime: number;
-  _playFromContinue: boolean;
-  _isPlaying: boolean;
+  _isPlaying: boolean = false;
+  _concurrentFlag: boolean = false;
+  _fileId: number = 0;
+  _didFirstPlay: boolean = false;
+  _mediaHitInterval: ?number = null;
+  _isPlaying: boolean = false;
 
   /**
    * @constructor
@@ -56,7 +54,6 @@ export default class OttAnalytics extends BasePlugin {
   constructor(name: string, player: Player, config: Object) {
     super(name, player, config);
     if (this.config.serviceUrl) {
-      this._initializeMembers();
       this._registerListeners();
     } else {
       this.logger.warn('No service URL provided. Tracking aborted');
@@ -106,6 +103,7 @@ export default class OttAnalytics extends BasePlugin {
     } catch (e) {
       this.logger.error(e);
     }
+  }
 
   /**
    * The media loaded event listener.
@@ -234,7 +232,7 @@ export default class OttAnalytics extends BasePlugin {
           this.logger.debug('Analytics event sent', bookMark);
         }
       }, err => {
-        this.logger.error('Failed to send analytics event', bookMark, err);
+        this.logger.warn('Failed to send analytics event', bookMark, err);
       });
   }
 
@@ -276,7 +274,6 @@ export default class OttAnalytics extends BasePlugin {
       this._clearMediaHitInterval();
       this._mediaHitInterval = setInterval(() => {
         if (this._isPlaying) {
-          this._playFromContinue = false;
           if (this._concurrentFlag || this._eventParams.position === 0) {
             return;
           } else {
@@ -293,28 +290,9 @@ export default class OttAnalytics extends BasePlugin {
    * @returns {void}
    */
   _clearMediaHitInterval(): void {
-    clearInterval(this._mediaHitInterval);
-    this._mediaHitInterval = 0;
-  }
-
-  /**
-   * Initializes the class members.
-   * @private
-   * @returns {void}
-   */
-  _initializeMembers(): void {
-    this._isPlaying = false;
-    this._concurrentFlag = false;
-    this._fileId = 0;
-    this._didFirstPlay = false;
-    this._mediaHitInterval = 0;
-    this._isPlaying = false;
-    if (this.config.startTime) {
-      this._continueTime = this.config.startTime;
-      this._playFromContinue = true;
-    } else {
-      this._continueTime = 0;
-      this._playFromContinue = false;
+    if (this._mediaHitInterval) {
+      clearInterval(this._mediaHitInterval);
+      this._mediaHitInterval = null;
     }
   }
 }

--- a/src/ott-analytics.js
+++ b/src/ott-analytics.js
@@ -58,7 +58,6 @@ export default class OttAnalytics extends BasePlugin {
     if (this.config.serviceUrl) {
       this._initializeMembers();
       this._registerListeners();
-      this._sendAnalytics(OttAnalyticsEvent.LOAD, this._eventParams);
     } else {
       this.logger.warn('No service URL provided. Tracking aborted');
     }
@@ -89,6 +88,7 @@ export default class OttAnalytics extends BasePlugin {
     this.eventManager.listen(this.player, PlayerEvent.VIDEO_TRACK_CHANGED, () => this._onVideoTrackChanged());
     this.eventManager.listen(this.player, PlayerEvent.CHANGE_SOURCE_STARTED, () => this._onChangeSourceStarted());
     this.eventManager.listen(this.player, PlayerEvent.SOURCE_SELECTED, event => this._onSourceSelected(event));
+    this.eventManager.listen(this.player, PlayerEvent.MEDIA_LOADED, () => this._onMediaLoaded());
   }
 
   /**
@@ -106,6 +106,14 @@ export default class OttAnalytics extends BasePlugin {
     } catch (e) {
       this.logger.error(e);
     }
+
+  /**
+   * The media loaded event listener.
+   * @private
+   * @returns {void}
+   */
+  _onMediaLoaded(): void {
+    this._sendAnalytics(OttAnalyticsEvent.LOAD, this._eventParams);
   }
 
   /**

--- a/src/ott-analytics.js
+++ b/src/ott-analytics.js
@@ -251,17 +251,19 @@ export default class OttAnalytics extends BasePlugin {
    * @returns {void}
    */
   _startMediaHitInterval(): void {
-    this._clearMediaHitInterval();
-    this._mediaHitInterval = setInterval(() => {
-      if (this._isPlaying) {
-        this._playFromContinue = false;
-        if (this._concurrentFlag || this._eventParams.position === 0) {
-          return;
-        } else {
-          this._sendAnalytics(OttAnalyticsEvent.HIT, this._eventParams);
+    if (!this.player.isLive()) {
+      this._clearMediaHitInterval();
+      this._mediaHitInterval = setInterval(() => {
+        if (this._isPlaying) {
+          this._playFromContinue = false;
+          if (this._concurrentFlag || this._eventParams.position === 0) {
+            return;
+          } else {
+            this._sendAnalytics(OttAnalyticsEvent.HIT, this._eventParams);
+          }
         }
-      }
-    }, this.config.mediaHitInterval * 1000);
+      }, this.config.mediaHitInterval * 1000);
+    }
   }
 
   /**

--- a/src/ott-analytics.js
+++ b/src/ott-analytics.js
@@ -243,8 +243,21 @@ export default class OttAnalytics extends BasePlugin {
       this._logMissingParam('ks');
       return false;
     }
+    if (!this.config.entryId) {
+      this._logMissingParam('entryId');
+      return false;
+    }
+    if (!this._fileId) {
+      this._logMissingParam('fileId');
+      return false;
+    }
     return true;
   }
+
+  _logMissingParam(missingParam: string): void {
+    this.logger.warn(`block report because of missing param ${missingParam}`);
+  }
+
   /**
    * Starts the media hit interval.
    * @private

--- a/test/src/ott-analytics.spec.js
+++ b/test/src/ott-analytics.spec.js
@@ -93,11 +93,27 @@ describe('OttAnalyticsPlugin', function () {
     sendSpy.callCount.should.equal(0);
   });
 
-  it('should send widget loaded', () => {
+  it('should send media loaded on calling to load method', (done) => {
     player = loadPlayer(config);
-    const payload = JSON.parse(sendSpy.lastCall.args[0]);
-    verifyPayloadProperties(payload.ks, payload.bookmark);
-    payload.bookmark.playerData.action.should.equal("LOAD");
+    player.addEventListener(player.Event.MEDIA_LOADED, () => {
+      const payload = JSON.parse(sendSpy.lastCall.args[0]);
+      verifyPayloadProperties(payload.ks, payload.bookmark);
+      payload.bookmark.playerData.action.should.equal("LOAD");
+      done();
+    });
+    player.load();
+  });
+
+  it('should send media loaded when preload is set to "auto"', (done) => {
+    config.playback = {preload: "auto"};
+    player = loadPlayer(config);
+    player.addEventListener(player.Event.MEDIA_LOADED, () => {
+      const payload = JSON.parse(sendSpy.lastCall.args[0]);
+      verifyPayloadProperties(payload.ks, payload.bookmark);
+      payload.bookmark.playerData.action.should.equal("LOAD");
+      config.playback = {preload: "none"};
+      done();
+    });
   });
 
   it('should send first play', (done) => {

--- a/test/src/ott-analytics.spec.js
+++ b/test/src/ott-analytics.spec.js
@@ -202,4 +202,25 @@ describe('OttAnalyticsPlugin', function () {
     player.addEventListener(player.Event.TIME_UPDATE, timeupdateHandler);
     player.play();
   });
+
+  it('should not send media hit if media type is LIVE', (done) => {
+    config.sources.type = "Live";
+    player = loadPlayer(config);
+    const timeupdateHandler = () => {
+      player.pause();
+      let error = null;
+      sendSpy.getCalls().forEach((call) => {
+        const payload = JSON.parse(call.args);
+        try {
+          payload.bookmark.playerData.action.should.not.equal("HIT");
+        } catch (e) {
+          error = e;
+        }
+      });
+      config.sources.type = "Vod";
+      done(error);
+    };
+    setTimeout(timeupdateHandler, 3000);
+    player.play();
+  });
 });

--- a/test/src/ott-analytics.spec.js
+++ b/test/src/ott-analytics.spec.js
@@ -20,6 +20,7 @@ describe('OttAnalyticsPlugin', function () {
 
   before(function () {
     config = {
+      "logLevel": "DEBUG",
       "id": 258457,
       "name": "Big Hero 6",
       "session": {
@@ -89,7 +90,7 @@ describe('OttAnalyticsPlugin', function () {
   it('should not send reports for anonymous users', () => {
     config.plugins.ottAnalytics.ks = undefined;
     player = loadPlayer(config);
-    (!(sendSpy.lastCall)).should.be.true;
+    sendSpy.callCount.should.equal(0);
   });
 
   it('should send widget loaded', () => {

--- a/test/src/ott-analytics.spec.js
+++ b/test/src/ott-analytics.spec.js
@@ -70,6 +70,7 @@ describe('OttAnalyticsPlugin', function () {
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
     sendSpy = sandbox.spy(XMLHttpRequest.prototype, 'send');
+    config.plugins.ottAnalytics.ks = config.session.ks;
     config.plugins.ottAnalytics.serviceUrl = "//api-preprod.ott.kaltura.com/v4_7/api_v3";
   });
 
@@ -81,6 +82,12 @@ describe('OttAnalyticsPlugin', function () {
 
   it('should do nothing if service URL not provided', () => {
     config.plugins.ottAnalytics.serviceUrl = undefined;
+    player = loadPlayer(config);
+    (!(sendSpy.lastCall)).should.be.true;
+  });
+
+  it('should not send reports for anonymous users', () => {
+    config.plugins.ottAnalytics.ks = undefined;
     player = loadPlayer(config);
     (!(sendSpy.lastCall)).should.be.true;
   });

--- a/test/src/ott-analytics.spec.js
+++ b/test/src/ott-analytics.spec.js
@@ -38,23 +38,23 @@ describe('OttAnalyticsPlugin', function () {
           "id": "397008,applehttp",
           "url": "//api-preprod.ott.kaltura.com/v4_7/api_v3/service/assetFile/action/playManifest/partnerId/198/assetId/258457/assetType/media/assetFileId/397008/contextType/TRAILER/a.m3u8",
           "mimetype": "application/x-mpegURL"
-        }]
-      },
-      "duration": 1000,
-      "type": "Unknown",
-      "dvr": false,
-      "metadata": {
-        "0": {"key": "Genre", "value": "Comedy|Action|Adventure|Animation|Family|Editor|"},
-        "1": {"key": "Parental Rating", "value": "G|R|"},
-        "2": {"key": "QUALITY", "value": "hd|sd|"},
-        "3": {"key": "Free", "value": "yes|no|adi|"},
-        "4": {"key": "Source", "value": "Web3|Editor|"},
-        "5": {"key": "Country", "value": ""},
-        "6": {"key": "QUALITY", "value": ""},
-        "7": {"key": "Epg ID", "value": ""},
-        "8": {"key": "Release year", "value": 2012},
-        "9": {"key": "Catchup allowed", "value": false},
-        "description": "*** Free *** The special bond that develops between plus-sized inflatable robot Baymax, and prodigy Hiro Hamada, who team up with a group of friends to form a band of high-tech heroes."
+        }],
+        "type": "Vod",
+        "duration": 1000,
+        "dvr": false,
+        "metadata": {
+          "0": {"key": "Genre", "value": "Comedy|Action|Adventure|Animation|Family|Editor|"},
+          "1": {"key": "Parental Rating", "value": "G|R|"},
+          "2": {"key": "QUALITY", "value": "hd|sd|"},
+          "3": {"key": "Free", "value": "yes|no|adi|"},
+          "4": {"key": "Source", "value": "Web3|Editor|"},
+          "5": {"key": "Country", "value": ""},
+          "6": {"key": "QUALITY", "value": ""},
+          "7": {"key": "Epg ID", "value": ""},
+          "8": {"key": "Release year", "value": 2012},
+          "9": {"key": "Catchup allowed", "value": false},
+          "description": "*** Free *** The special bond that develops between plus-sized inflatable robot Baymax, and prodigy Hiro Hamada, who team up with a group of friends to form a band of high-tech heroes."
+        }
       }
     };
     config.plugins = {
@@ -152,6 +152,54 @@ describe('OttAnalyticsPlugin', function () {
       }
       done();
     });
+    player.play();
+  });
+
+  it('should not send media hit if configured to disable', (done) => {
+    config.plugins.ottAnalytics.disableMediaHit = true;
+    player = loadPlayer(config);
+    const timeupdateHandler = () => {
+      if (player.currentTime > 3) {
+        player.pause();
+        let error = null;
+        sendSpy.getCalls().forEach((call) => {
+          const payload = JSON.parse(call.args);
+          try {
+            payload.bookmark.playerData.action.should.not.equal("HIT");
+          } catch (e) {
+            error = e;
+          }
+        });
+        player.removeEventListener(player.Event.TIME_UPDATE, timeupdateHandler);
+        config.plugins.ottAnalytics.disableMediaHit = false;
+        done(error);
+      }
+    };
+    player.addEventListener(player.Event.TIME_UPDATE, timeupdateHandler);
+    player.play();
+  });
+
+  it('should not send media mark if configured to disable', (done) => {
+    config.plugins.ottAnalytics.disableMediaMark = true;
+    player = loadPlayer(config);
+    const timeupdateHandler = () => {
+      if (player.currentTime > 3) {
+        player.pause();
+        let error = null;
+        sendSpy.getCalls().forEach((call) => {
+          const payload = JSON.parse(call.args);
+          try {
+            payload.bookmark.playerData.action.should.equal("HIT");
+          } catch (e) {
+            error = e;
+          }
+        });
+        player.removeEventListener(player.Event.TIME_UPDATE, timeupdateHandler);
+        config.plugins.ottAnalytics.disableMediaMark = false;
+        done(error);
+      }
+    };
+    player.addEventListener(player.Event.TIME_UPDATE, timeupdateHandler);
     player.play();
   });
 });


### PR DESCRIPTION
load event should be sent only when media is loaded, either when preload is auto, load method is called on API or play is requested, where we internally call load as well.