### PR TITLE
fix(FEC-8331): use isAnonymous flag from config instead of ks

### DIFF
--- a/src/ott-analytics.js
+++ b/src/ott-analytics.js
@@ -24,6 +24,7 @@ export default class OttAnalytics extends BasePlugin {
   static defaultConfig: Object = {
     mediaHitInterval: 30,
     startTime: null,
+    isAnonymous: true,
     disableMediaHit: false,
     disableMediaMark: false
   };
@@ -237,6 +238,18 @@ export default class OttAnalytics extends BasePlugin {
   }
 
   _validate(action: string): boolean {
+    if (!this.config.entryId) {
+      this._logMissingParam('entryId');
+      return false;
+    }
+    if (!this._fileId) {
+      this._logMissingParam('fileId');
+      return false;
+    }
+    if (this.config.isAnonymous) {
+      this.logger.info(`block report for anonymous user`);
+      return false;
+    }
     const isMediaHit = action === OttAnalyticsEvent.HIT;
     if (isMediaHit && this.config.disableMediaHit) {
       this.logger.info(`block MediaHit report`);
@@ -244,18 +257,6 @@ export default class OttAnalytics extends BasePlugin {
     }
     if (!isMediaHit && this.config.disableMediaMark) {
       this.logger.info(`block MediaMark report`);
-      return false;
-    }
-    if (!this.config.ks) {
-      this._logMissingParam('ks');
-      return false;
-    }
-    if (!this.config.entryId) {
-      this._logMissingParam('entryId');
-      return false;
-    }
-    if (!this._fileId) {
-      this._logMissingParam('fileId');
       return false;
     }
     return true;

--- a/test/src/ott-analytics.spec.js
+++ b/test/src/ott-analytics.spec.js
@@ -72,6 +72,7 @@ describe('OttAnalyticsPlugin', function () {
     sandbox = sinon.sandbox.create();
     sendSpy = sandbox.spy(XMLHttpRequest.prototype, 'send');
     config.plugins.ottAnalytics.ks = config.session.ks;
+    config.plugins.ottAnalytics.isAnonymous = false;
     config.plugins.ottAnalytics.serviceUrl = "//api-preprod.ott.kaltura.com/v4_7/api_v3";
   });
 
@@ -88,7 +89,7 @@ describe('OttAnalyticsPlugin', function () {
   });
 
   it('should not send reports for anonymous users', () => {
-    config.plugins.ottAnalytics.ks = undefined;
+    config.plugins.ottAnalytics.isAnonymous = true;
     player = loadPlayer(config);
     sendSpy.callCount.should.equal(0);
   });


### PR DESCRIPTION
using KS to know if session is anonymous is not good, as even anonymous login has an anonymous ks, so need to add setting to plugin to know if it is an anonymous login or not.
this will be autopopulated by the kaltura player that will get it from the provider, which has the ability to know if session is anonymous or not as it is generating the anonymous KS in case non was given to it.