### PR TITLE
 fix(FEC-8336): stop sending reports after critical player error

### DIFF
--- a/src/ott-analytics.js
+++ b/src/ott-analytics.js
@@ -1,5 +1,5 @@
 //@flow
-import {BasePlugin} from 'playkit-js'
+import {BasePlugin, Error, FakeEvent} from 'playkit-js'
 import {OTTBookmarkService, RequestBuilder} from 'playkit-js-providers/dist/playkit-bookmark-service'
 
 type OttAnalyticsEventType = { [event: string]: string };
@@ -83,6 +83,7 @@ export default class OttAnalytics extends BasePlugin {
     this.eventManager.listen(this.player, PlayerEvent.PAUSE, () => this._onPause());
     this.eventManager.listen(this.player, PlayerEvent.ENDED, () => this._onEnded());
     this.eventManager.listen(this.player, PlayerEvent.SEEKED, () => this._onSeeked());
+    this.eventManager.listen(this.player, PlayerEvent.ERROR, (e) => this._onError(e));
     this.eventManager.listen(this.player, PlayerEvent.VIDEO_TRACK_CHANGED, () => this._onVideoTrackChanged());
     this.eventManager.listen(this.player, PlayerEvent.CHANGE_SOURCE_STARTED, () => this._onChangeSourceStarted());
     this.eventManager.listen(this.player, PlayerEvent.SOURCE_SELECTED, event => this._onSourceSelected(event));
@@ -147,6 +148,19 @@ export default class OttAnalytics extends BasePlugin {
     this._isPlaying = false;
     this._clearMediaHitInterval();
     this._sendAnalytics(OttAnalyticsEvent.FINISH, this._eventParams);
+  }
+
+  /**
+   * The error event listener.
+   * @param {FakeEvent} event - player eventgit chec
+   * @private
+   * @returns {void}
+   */
+  _onError(event: FakeEvent): void {
+    if (event.payload && event.payload.severity === Error.Severity.CRITICAL) {
+      this._isPlaying = false;
+      this._clearMediaHitInterval();
+    }
   }
 
   /**

--- a/src/ott-analytics.js
+++ b/src/ott-analytics.js
@@ -44,7 +44,7 @@ export default class OttAnalytics extends BasePlugin {
   _fileId: number = 0;
   _didFirstPlay: boolean = false;
   _mediaHitInterval: ?number = null;
-  _isPlaying: boolean = false;
+  _playerDidError: boolean = false;
 
   /**
    * @constructor
@@ -59,6 +59,18 @@ export default class OttAnalytics extends BasePlugin {
     } else {
       this.logger.warn('No service URL provided. Tracking aborted');
     }
+  }
+
+  /**
+   * reset the plugin.
+   * @override
+   * @public
+   * @returns {void}
+   */
+  reset(): void {
+    this._clearMediaHitInterval();
+    this._didFirstPlay = false;
+    this._playerDidError = false;
   }
 
   /**
@@ -85,7 +97,6 @@ export default class OttAnalytics extends BasePlugin {
     this.eventManager.listen(this.player, PlayerEvent.SEEKED, () => this._onSeeked());
     this.eventManager.listen(this.player, PlayerEvent.ERROR, (e) => this._onError(e));
     this.eventManager.listen(this.player, PlayerEvent.VIDEO_TRACK_CHANGED, () => this._onVideoTrackChanged());
-    this.eventManager.listen(this.player, PlayerEvent.CHANGE_SOURCE_STARTED, () => this._onChangeSourceStarted());
     this.eventManager.listen(this.player, PlayerEvent.SOURCE_SELECTED, event => this._onSourceSelected(event));
     this.eventManager.listen(this.player, PlayerEvent.MEDIA_LOADED, () => this._onMediaLoaded());
   }
@@ -159,6 +170,7 @@ export default class OttAnalytics extends BasePlugin {
   _onError(event: FakeEvent): void {
     if (event.payload && event.payload.severity === Error.Severity.CRITICAL) {
       this._isPlaying = false;
+      this._playerDidError = true;
       this._clearMediaHitInterval();
     }
   }
@@ -189,15 +201,6 @@ export default class OttAnalytics extends BasePlugin {
    */
   _onVideoTrackChanged(): void {
     this._sendAnalytics(OttAnalyticsEvent.BITRATE_CHANGE, this._eventParams);
-  }
-
-  /**
-   * Sets _didFirstPlay to false on media change.
-   * @private
-   * @returns {void}
-   */
-  _onChangeSourceStarted(): void {
-    this._didFirstPlay = false;
   }
 
   /**
@@ -252,6 +255,9 @@ export default class OttAnalytics extends BasePlugin {
   }
 
   _validate(action: string): boolean {
+    if (this._playerDidError) {
+      return false;
+    }
     if (!this.config.entryId) {
       this._logMissingParam('entryId');
       return false;

--- a/test/src/ott-analytics.spec.js
+++ b/test/src/ott-analytics.spec.js
@@ -1,5 +1,5 @@
 import '../../src/index'
-import {loadPlayer} from 'playkit-js'
+import {loadPlayer, Error, FakeEvent, EventType} from 'playkit-js'
 import * as TestUtils from 'playkit-js/test/src/utils/test-utils'
 
 describe('OttAnalyticsPlugin', function () {
@@ -224,7 +224,7 @@ describe('OttAnalyticsPlugin', function () {
   it('should not send media hit if media type is LIVE', (done) => {
     config.sources.type = "Live";
     player = loadPlayer(config);
-    const timeupdateHandler = () => {
+    const timeoutHandler = () => {
       player.pause();
       let error = null;
       sendSpy.getCalls().forEach((call) => {
@@ -238,7 +238,29 @@ describe('OttAnalyticsPlugin', function () {
       config.sources.type = "Vod";
       done(error);
     };
-    setTimeout(timeupdateHandler, 3000);
+    setTimeout(timeoutHandler, 3000);
+    player.play();
+  });
+
+  it('should not send media hit/mark after critical player error', (done) => {
+    player = loadPlayer(config);
+    this.numberOfReprots = 0;
+    const timeoutHandler = () => {
+      const error = new Error(Error.Severity.CRITICAL, Error.Category.PLAYER, Error.Code.RUNTIME_ERROR_METHOD_NOT_IMPLEMENTED, 'static canPlayDrm');
+      player.dispatchEvent(new FakeEvent(EventType.ERROR, error));
+      this.numberOfReprots = sendSpy.getCalls().length;
+      setTimeout(errorTimeoutHandler, 3000);
+    };
+    const errorTimeoutHandler = () => {
+      player.pause();
+      try {
+        sendSpy.getCalls().length.should.equal(this.numberOfReprots);
+        done();
+      } catch (e) {
+        done(e);
+      }
+    };
+    setTimeout(timeoutHandler, 3000);
     player.play();
   });
 });


### PR DESCRIPTION
Upon critical player error the analytics reports should stop, and only resume after a change media was done