### PR TITLE
feat(FEC-8558): concurrency handling

### DIFF
--- a/src/ott-analytics.js
+++ b/src/ott-analytics.js
@@ -243,19 +243,14 @@ export default class OttAnalytics extends BasePlugin {
     const request: RequestBuilder = OTTBookmarkService.add(this.config.serviceUrl, this.config.ks, bookMark);
     request.doHttpRequest().then(
       data => {
-        if (data === CONCURRENT ) {
-          this._concurrentFlag = true;  
-          this.player.dispatchEvent(new FakeEvent('Concurrent Block', data));
-        else {
           var o = JSON.parse(data);
           // Handle this format: {"result": {"error": {"objectType": "KalturaAPIException","code": 4001,"message": "Concurrent play limitation"}}}
-          if (o.result && o.result.error && o.result.error.message.indexof(CONCURRENT) >= 0){  
+          if (o.result && o.result.error && o.result.error.message && o.result.error.message.indexof(CONCURRENT) >= 0){  
             this._concurrentFlag = true;
             this.player.dispatchEvent(new FakeEvent('Concurrent Block', data));
           } else {
             this.logger.debug('Analytics event sent', bookMark);
           }
-        }
       },
       err => {
         this.logger.warn('Failed to send analytics event', bookMark, err);

--- a/src/ott-analytics.js
+++ b/src/ott-analytics.js
@@ -243,11 +243,12 @@ export default class OttAnalytics extends BasePlugin {
     const request: RequestBuilder = OTTBookmarkService.add(this.config.serviceUrl, this.config.ks, bookMark);
     request.doHttpRequest().then(
       data => {
-          var o = JSON.parse(data);
+          const o = JSON.parse(data);
           // Handle this format: {"result": {"error": {"objectType": "KalturaAPIException","code": 4001,"message": "Concurrent play limitation"}}}
-          if (o.result && o.result.error && o.result.error.message && o.result.error.message.indexof(CONCURRENT) >= 0){  
+          if (o.result && o.result.error && o.result.error.code && o.result.error.code === 4001){  
             this._concurrentFlag = true;
-            this.player.dispatchEvent(new FakeEvent('Concurrent Block', data));
+            this.player.dispatchEvent(new FakeEvent('phoenixConcurrentBlock', data));
+            this.logger.debug('Analytics concurrency block returned', o);
           } else {
             this.logger.debug('Analytics event sent', bookMark);
           }

--- a/src/ott-analytics.js
+++ b/src/ott-analytics.js
@@ -243,6 +243,7 @@ export default class OttAnalytics extends BasePlugin {
     const request: RequestBuilder = OTTBookmarkService.add(this.config.serviceUrl, this.config.ks, bookMark);
     request.doHttpRequest().then(
       data => {
+        try{
           const o = JSON.parse(data);
           // Handle this format: {"result": {"error": {"objectType": "KalturaAPIException","code": 4001,"message": "Concurrent play limitation"}}}
           if (o.result && o.result.error && o.result.error.code && o.result.error.code === 4001){  
@@ -252,6 +253,9 @@ export default class OttAnalytics extends BasePlugin {
           } else {
             this.logger.debug('Analytics event sent', bookMark);
           }
+        } catch(e){
+          this.logger.debug('Analytics response parsing failed', data);
+        }
       },
       err => {
         this.logger.warn('Failed to send analytics event', bookMark, err);


### PR DESCRIPTION
- Handle pheonix response  ({"result": {"error": {"objectType": "KalturaAPIException","code": 4001,"message": "Concurrent play limitation"}}} to set concurrency flag
- Do not send bookmarks in case concurrency flag is set
- Dispatch event when concurrency is hit (FE should listen to this event and handle UI accordingly)

### Description of the Changes

Please add a detailed description of the change, weather it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
