### PR TITLE
feat(FEC-8695): add STOP bookmark event

### DIFF
--- a/src/ott-analytics.js
+++ b/src/ott-analytics.js
@@ -42,6 +42,7 @@ export default class OttAnalytics extends BasePlugin {
 
   _isPlaying: boolean = false;
   _isFinished: boolean = false;
+  _isStopped: boolean = false;
   _concurrentFlag: boolean = false;
   _fileId: number = 0;
   _didFirstPlay: boolean = false;
@@ -71,11 +72,7 @@ export default class OttAnalytics extends BasePlugin {
    */
   reset(): void {
     this._clearMediaHitInterval();
-    if (this._isFinished) {
-      this._isFinished = false;
-    } else {
-      this._sendAnalytics(OttAnalyticsEvent.STOP, this._eventParams);
-    }
+    this._maybeSendStop();
     this._didFirstPlay = false;
     this._playerDidError = false;
   }
@@ -87,8 +84,15 @@ export default class OttAnalytics extends BasePlugin {
    * @returns {void}
    */
   destroy(): void {
-    this.reset();
+    this._maybeSendStop();
     this.eventManager.destroy();
+  }
+
+  _maybeSendStop() {
+    if (!(this._isFinished || this._isStopped)) {
+      this._isStopped = true;
+      this._sendAnalytics(OttAnalyticsEvent.STOP, this._eventParams);
+    }
   }
 
   /**
@@ -142,6 +146,8 @@ export default class OttAnalytics extends BasePlugin {
    */
   _onPlay(): void {
     this._isPlaying = true;
+    this._isStopped = false;
+    this._isFinished = false;
     this._startMediaHitInterval();
     this._sendAnalytics(OttAnalyticsEvent.PLAY, this._eventParams);
   }

--- a/src/ott-analytics.js
+++ b/src/ott-analytics.js
@@ -7,6 +7,7 @@ const MEDIA_TYPE = 'MEDIA';
 const OttAnalyticsEvent: OttAnalyticsEventType = {
   LOAD: 'LOAD',
   PLAY: 'PLAY',
+  STOP: 'STOP',
   PAUSE: 'PAUSE',
   FINISH: 'FINISH',
   FIRST_PLAY: 'FIRST_PLAY',
@@ -22,6 +23,7 @@ export default class OttAnalytics extends BasePlugin {
    */
   static defaultConfig: Object = {
     mediaHitInterval: 30,
+    isAnonymous: true,
     startTime: null,
     disableMediaHit: false,
     disableMediaMark: false,
@@ -39,6 +41,7 @@ export default class OttAnalytics extends BasePlugin {
   }
 
   _isPlaying: boolean = false;
+  _isFinished: boolean = false;
   _concurrentFlag: boolean = false;
   _fileId: number = 0;
   _didFirstPlay: boolean = false;
@@ -68,6 +71,11 @@ export default class OttAnalytics extends BasePlugin {
    */
   reset(): void {
     this._clearMediaHitInterval();
+    if (this._isFinished) {
+      this._isFinished = false;
+    } else {
+      this._sendAnalytics(OttAnalyticsEvent.STOP, this._eventParams);
+    }
     this._didFirstPlay = false;
     this._playerDidError = false;
   }
@@ -79,6 +87,7 @@ export default class OttAnalytics extends BasePlugin {
    * @returns {void}
    */
   destroy(): void {
+    this.reset();
     this.eventManager.destroy();
   }
 
@@ -156,6 +165,7 @@ export default class OttAnalytics extends BasePlugin {
    */
   _onEnded(): void {
     this._isPlaying = false;
+    this._isFinished = true;
     this._clearMediaHitInterval();
     this._sendAnalytics(OttAnalyticsEvent.FINISH, this._eventParams);
   }


### PR DESCRIPTION
### Description of the Changes

when media playback is stopped before it ended(either destroy is called or change media or reset) then send bookmark stop event.
Will add tests once #18 is merged as it contains the unit test boilerplate code.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
