### PR TITLE
chore: Webpack doesn't have `umdNamedDefine`

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,7 @@ module.exports = {
     filename: '[name].js',
     library: ['playkit', 'ottanalytics'],
     libraryTarget: 'umd',
+    umdNamedDefine: true,
     devtoolModuleFilenameTemplate: './ott-analytics/[resource-path]'
   },
   devtool: 'source-map',


### PR DESCRIPTION
### Description of the Changes

Webpack doesn't have `umdNamedDefine` and Kaltura player could use it.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
