### PR TITLE
build: canary change provider dep to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,11 @@ jobs:
     - stage: Release canary
       if: (branch = master) AND (type != pull_request) AND commit_message !~ /^chore\(release\)/
       env: TRAVIS_MODE=releaseCanary
+      before_script:
+        - yarn remove playkit-js-providers
+        - yarn add playkit-js-providers@https://github.com/kaltura/playkit-js-providers.git#master -P
+        - yarn add playkit-js-providers@https://github.com/kaltura/playkit-js-providers.git#master -D
+        - yarn install
       deploy:
         provider: npm
         api_key: $NPM_TOKEN


### PR DESCRIPTION
### Description of the Changes

Issue: kava canary has a fixed version of providers.
Solution: canary version will build with providers master.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
