### PR TITLE
fix(FEC-11541): position in live ott is wrong

### DIFF
--- a/src/ott-analytics.js
+++ b/src/ott-analytics.js
@@ -237,7 +237,7 @@ class OttAnalytics extends BasePlugin {
         : MEDIA_TYPE,
       fileId: this._fileId,
       mediaId: this.config.entryId,
-      position: this.player.currentTime
+      position: this.player.isLive() ? this.player.currentTime - this.player.getStartTimeOfDvrWindow() : this.player.currentTime
     };
   }
 


### PR DESCRIPTION
### Description of the Changes

**the issue:**
position in ott live should be returning the calculation of currentTime - startTime.

**the solution:**
returning the above calculation when in live.

Solves FEC-11541

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
