### PR TITLE
feat(FEC-11611): [Web] Pass the program ID when sending a bookmark

### DIFF
--- a/flow-typed/types/ott-analytics-config.js
+++ b/flow-typed/types/ott-analytics-config.js
@@ -1,0 +1,10 @@
+// @flow
+declare type OttAnalyticsConfig = {
+  mediaHitInterval: number,
+  isAnonymous: boolean,
+  startTime: number,
+  disableMediaHit: boolean,
+  disableMediaMark: boolean,
+  experimentalEnableLiveMediaHit: boolean,
+  epgId: string
+};

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   "peerDependencies": {
     "@playkit-js/playkit-js": "0.63.0",
     "kaltura-player-js": "https://github.com/kaltura/kaltura-player-js.git#master",
-    "playkit-js-providers": "https://github.com/kaltura/playkit-js-providers.git#v2.22.0"
+    "playkit-js-providers": "https://github.com/kaltura/playkit-js-providers.git#FEC-11611"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "lint-staged": "^10.2.11",
     "mocha": "^8.0.1",
     "mocha-cli": "^1.0.1",
-    "playkit-js-providers": "https://github.com/kaltura/playkit-js-providers.git#v2.22.0",
+    "playkit-js-providers": "https://github.com/kaltura/playkit-js-providers.git#master",
     "prettier": "^2.0.5",
     "sinon": "^9.0.2",
     "sinon-chai": "^3.5.0",
@@ -101,7 +101,7 @@
   "peerDependencies": {
     "@playkit-js/playkit-js": "0.63.0",
     "kaltura-player-js": "https://github.com/kaltura/kaltura-player-js.git#master",
-    "playkit-js-providers": "https://github.com/kaltura/playkit-js-providers.git#FEC-11611"
+    "playkit-js-providers": "https://github.com/kaltura/playkit-js-providers.git#master"
   },
   "publishConfig": {
     "access": "public"

--- a/src/ott-analytics.js
+++ b/src/ott-analytics.js
@@ -35,7 +35,8 @@ class OttAnalytics extends BasePlugin {
     startTime: null,
     disableMediaHit: false,
     disableMediaMark: false,
-    experimentalEnableLiveMediaHit: false
+    experimentalEnableLiveMediaHit: false,
+    epgId: null
   };
 
   /**
@@ -61,9 +62,9 @@ class OttAnalytics extends BasePlugin {
    * @constructor
    * @param {string} name - The plugin name.
    * @param {Player} player - The player instance.
-   * @param {Object} config - The plugin config.
+   * @param {OttAnalyticsConfig} config - The OttAnalytics plugin config.
    */
-  constructor(name: string, player: Player, config: Object) {
+  constructor(name: string, player: Player, config: OttAnalyticsConfig) {
     super(name, player, config);
     if (this.config.serviceUrl) {
       this._registerListeners();
@@ -84,6 +85,7 @@ class OttAnalytics extends BasePlugin {
     this._didFirstPlay = false;
     this._playerDidError = false;
     this._isLoaded = false;
+    this.updateConfig({epgId: null});
   }
 
   /**
@@ -251,10 +253,18 @@ class OttAnalytics extends BasePlugin {
         : this.config.entryId,
       position: this._getPosition()
     };
-    if (Utils.Object.hasPropertyPath(this.player.sources, 'metadata.epgId')) {
-      eventParams.programId = this.player.sources.metadata.epgId;
-    }
+    const epgId = this._getEpgId();
+    if (epgId) eventParams.programId = epgId;
     return eventParams;
+  }
+
+  _getEpgId(): string | null {
+    if (this.config.epgId) {
+      return this.config.epgId;
+    } else if (Utils.Object.hasPropertyPath(this.player.sources, 'metadata.epgId')) {
+      return this.player.sources.metadata.epgId;
+    }
+    return null;
   }
 
   /**

--- a/src/ott-analytics.js
+++ b/src/ott-analytics.js
@@ -243,14 +243,18 @@ class OttAnalytics extends BasePlugin {
    * @returns {Object} - The player params
    */
   get _eventParams(): Object {
-    return {
-      mediaType: Utils.Object.hasPropertyPath(this.player.config, 'sources.metadata.mediaType')
-        ? this.player.config.sources.metadata.mediaType
-        : MEDIA_TYPE,
+    const eventParams: Object = {
+      mediaType: Utils.Object.hasPropertyPath(this.player.sources, 'metadata.mediaType') ? this.player.sources.metadata.mediaType : MEDIA_TYPE,
       fileId: this._fileId,
-      mediaId: this.config.entryId,
+      mediaId: Utils.Object.hasPropertyPath(this.player.sources, 'metadata.recordingId')
+        ? this.player.sources.metadata.recordingId
+        : this.config.entryId,
       position: this._getPosition()
     };
+    if (Utils.Object.hasPropertyPath(this.player.sources, 'metadata.epgId')) {
+      eventParams.programId = this.player.sources.metadata.epgId;
+    }
+    return eventParams;
   }
 
   /**
@@ -289,6 +293,9 @@ class OttAnalytics extends BasePlugin {
       position: params.position,
       playerData: playerData
     };
+    if (params.programId) {
+      bookMark.programId = params.programId;
+    }
     const request: RequestBuilder = OTTBookmarkService.add(this.config.serviceUrl, this.config.ks, bookMark);
     this.logger.debug('sending bookmark', bookMark);
     request.doHttpRequest().then(

--- a/src/ott-analytics.js
+++ b/src/ott-analytics.js
@@ -35,8 +35,7 @@ class OttAnalytics extends BasePlugin {
     startTime: null,
     disableMediaHit: false,
     disableMediaMark: false,
-    experimentalEnableLiveMediaHit: false,
-    epgId: null
+    experimentalEnableLiveMediaHit: false
   };
 
   /**
@@ -85,7 +84,6 @@ class OttAnalytics extends BasePlugin {
     this._didFirstPlay = false;
     this._playerDidError = false;
     this._isLoaded = false;
-    this.updateConfig({epgId: null});
   }
 
   /**
@@ -253,18 +251,10 @@ class OttAnalytics extends BasePlugin {
         : this.config.entryId,
       position: this._getPosition()
     };
-    const epgId = this._getEpgId();
-    if (epgId) eventParams.programId = epgId;
-    return eventParams;
-  }
-
-  _getEpgId(): string | null {
-    if (this.config.epgId) {
-      return this.config.epgId;
-    } else if (Utils.Object.hasPropertyPath(this.player.sources, 'metadata.epgId')) {
-      return this.player.sources.metadata.epgId;
+    if (Utils.Object.hasPropertyPath(this.player.sources, 'metadata.epgId')) {
+      eventParams.programId = this.player.sources.metadata.epgId;
     }
-    return null;
+    return eventParams;
   }
 
   /**

--- a/test/src/ott-analytics.spec.js
+++ b/test/src/ott-analytics.spec.js
@@ -354,7 +354,7 @@ describe('OttAnalyticsPlugin', function () {
     player.addEventListener(player.Event.PLAY, () => {
       try {
         const payload = JSON.parse(sendSpy.lastCall.args[0]);
-        verifyPayloadProperties(payload.ks, payload.bookmark);
+        //verifyPayloadProperties(payload.ks, payload.bookmark);
         payload.bookmark.playerData.action.should.equal('PLAY');
         payload.bookmark.programId.should.equal('454032891');
         delete config.sources.metadata.epgId;

--- a/test/src/ott-analytics.spec.js
+++ b/test/src/ott-analytics.spec.js
@@ -367,13 +367,13 @@ describe('OttAnalyticsPlugin', function () {
   });
 
   it('should send PLAY with recordingId as id param instead of entryId when it exist', done => {
-    config.sources.metadata.recordingId = '777032895';
+    config.sources.metadata.recordingId = '747032895';
     player = setup(config);
     player.addEventListener(player.Event.PLAY, () => {
       try {
         const payload = JSON.parse(sendSpy.lastCall.args[0]);
         payload.bookmark.playerData.action.should.equal('PLAY');
-        payload.bookmark.id.should.equal('777032895');
+        payload.bookmark.id.should.equal('747032895');
         delete config.sources.metadata.recordingId;
         done();
       } catch (e) {

--- a/test/src/ott-analytics.spec.js
+++ b/test/src/ott-analytics.spec.js
@@ -348,6 +348,41 @@ describe('OttAnalyticsPlugin', function () {
     player.play();
   });
 
+  it('should send PLAY with epgId as programId param when it exists', done => {
+    config.sources.metadata.epgId = '454032895';
+    player = setup(config);
+    player.addEventListener(player.Event.PLAY, () => {
+      try {
+        const payload = JSON.parse(sendSpy.lastCall.args[0]);
+        verifyPayloadProperties(payload.ks, payload.bookmark);
+        payload.bookmark.playerData.action.should.equal('PLAY');
+        payload.bookmark.programId.should.equal('454032895');
+        delete config.sources.metadata.epgId;
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
+    player.play();
+  });
+
+  it('should send PLAY with recordingId as id param instead of entryId when it exist', done => {
+    config.sources.metadata.recordingId = '777032895';
+    player = setup(config);
+    player.addEventListener(player.Event.PLAY, () => {
+      try {
+        const payload = JSON.parse(sendSpy.lastCall.args[0]);
+        payload.bookmark.playerData.action.should.equal('PLAY');
+        payload.bookmark.id.should.equal('777032895');
+        delete config.sources.metadata.recordingId;
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
+    player.play();
+  });
+
   it('should send pause', done => {
     player = setup(config);
     player.addEventListener(player.Event.PAUSE, () => {

--- a/test/src/ott-analytics.spec.js
+++ b/test/src/ott-analytics.spec.js
@@ -349,14 +349,14 @@ describe('OttAnalyticsPlugin', function () {
   });
 
   it('should send PLAY with epgId as programId param when it exists', done => {
-    config.sources.metadata.epgId = '454032895';
+    config.sources.metadata.epgId = '454032891';
     player = setup(config);
     player.addEventListener(player.Event.PLAY, () => {
       try {
         const payload = JSON.parse(sendSpy.lastCall.args[0]);
         verifyPayloadProperties(payload.ks, payload.bookmark);
         payload.bookmark.playerData.action.should.equal('PLAY');
-        payload.bookmark.programId.should.equal('454032895');
+        payload.bookmark.programId.should.equal('454032891');
         delete config.sources.metadata.epgId;
         done();
       } catch (e) {

--- a/test/src/ott-analytics.spec.js
+++ b/test/src/ott-analytics.spec.js
@@ -349,14 +349,14 @@ describe('OttAnalyticsPlugin', function () {
   });
 
   it('should send PLAY with epgId as programId param when it exists', done => {
-    config.sources.metadata.epgId = '454032891';
+    config.sources.metadata.epgId = '452032891';
     player = setup(config);
     player.addEventListener(player.Event.FIRST_PLAY, () => {
       try {
         const payload = JSON.parse(sendSpy.lastCall.args[0]);
         verifyPayloadProperties(payload.ks, payload.bookmark);
         payload.bookmark.playerData.action.should.equal('FIRST_PLAY');
-        payload.bookmark.programId.should.equal('454032891');
+        payload.bookmark.programId.should.equal('452032891');
         delete config.sources.metadata.epgId;
         done();
       } catch (e) {

--- a/test/src/ott-analytics.spec.js
+++ b/test/src/ott-analytics.spec.js
@@ -351,11 +351,11 @@ describe('OttAnalyticsPlugin', function () {
   it('should send PLAY with epgId as programId param when it exists', done => {
     config.sources.metadata.epgId = '454032891';
     player = setup(config);
-    player.addEventListener(player.Event.PLAY, () => {
+    player.addEventListener(player.Event.FIRST_PLAY, () => {
       try {
         const payload = JSON.parse(sendSpy.lastCall.args[0]);
-        //verifyPayloadProperties(payload.ks, payload.bookmark);
-        payload.bookmark.playerData.action.should.equal('PLAY');
+        verifyPayloadProperties(payload.ks, payload.bookmark);
+        payload.bookmark.playerData.action.should.equal('FIRST_PLAY');
         payload.bookmark.programId.should.equal('454032891');
         delete config.sources.metadata.epgId;
         done();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6235,11 +6235,9 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   version "2.30.0"
   resolved "https://github.com/kaltura/playkit-js-providers#d1aadd54a59fd2a6377653730fc1a83b9dfdb1b2"
 
-"playkit-js-providers@https://github.com/kaltura/playkit-js-providers.git#v2.22.0":
-  version "2.22.0"
-  resolved "https://github.com/kaltura/playkit-js-providers.git#bf485afe2f71e8ddf6949ee70d94d2f1045527f5"
-  dependencies:
-    js-logger "^1.6.0"
+"playkit-js-providers@https://github.com/kaltura/playkit-js-providers.git#master":
+  version "2.30.0"
+  resolved "https://github.com/kaltura/playkit-js-providers.git#bf35e435f334eda584079b2fe0e866fffec5ca39"
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
### Description of the Changes

pass the epgid metadata as program ID parameter when sending a bookmark
pass the recordingId metadata as id parameter instead of entryId when sending a bookmark

related pr: 
https://github.com/kaltura/playkit-js-providers/pull/155
https://github.com/kaltura/playkit-js/pull/615
https://github.com/kaltura/kaltura-player-js/pull/504
https://github.com/kaltura/kaltura-player-js/pull/503

Solves FEC-11611

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
