### PR TITLE
fix(FEC-127873): incase of CATCHUP, START_OVER and RECORDING use bookmark mediaId as programId

### DIFF
--- a/src/ott-analytics.js
+++ b/src/ott-analytics.js
@@ -1,6 +1,7 @@
 //@flow
 import {core, BasePlugin} from 'kaltura-player-js';
 import {OTTBookmarkService, RequestBuilder} from 'playkit-js-providers/dist/playkit-bookmark-service';
+import {ContextType, MediaType} from 'playkit-js-providers';
 
 type OttAnalyticsEventType = {[event: string]: string};
 const {Error, FakeEvent, Utils} = core;
@@ -255,7 +256,13 @@ class OttAnalytics extends BasePlugin {
         : this.config.entryId,
       position: this._getPosition()
     };
-    if (Utils.Object.hasPropertyPath(this.player.sources, 'metadata.epgId')) {
+    if (
+      eventParams.mediaType === MediaType.RECORDING ||
+      eventParams.contextType === ContextType.CATCHUP ||
+      eventParams.contextTyp === ContextType.START_OVER
+    ) {
+      eventParams.programId = eventParams.mediaId;
+    } else if (Utils.Object.hasPropertyPath(this.player.sources, 'metadata.epgId')) {
       eventParams.programId = this.player.sources.metadata.epgId;
     }
     return eventParams;

--- a/src/ott-analytics.js
+++ b/src/ott-analytics.js
@@ -1,7 +1,6 @@
 //@flow
-import {core, BasePlugin} from 'kaltura-player-js';
+import {core, BasePlugin, providers} from 'kaltura-player-js';
 import {OTTBookmarkService, RequestBuilder} from 'playkit-js-providers/dist/playkit-bookmark-service';
-import {ContextType, MediaType} from 'playkit-js-providers';
 
 type OttAnalyticsEventType = {[event: string]: string};
 const {Error, FakeEvent, Utils} = core;
@@ -257,9 +256,9 @@ class OttAnalytics extends BasePlugin {
       position: this._getPosition()
     };
     if (
-      eventParams.mediaType === MediaType.RECORDING ||
-      eventParams.contextType === ContextType.CATCHUP ||
-      eventParams.contextTyp === ContextType.START_OVER
+      eventParams.mediaType === providers.MediaType.RECORDING ||
+      eventParams.contextType === providers.ContextType.CATCHUP ||
+      eventParams.contextTyp === providers.ContextType.START_OVER
     ) {
       eventParams.programId = eventParams.mediaId;
     } else if (Utils.Object.hasPropertyPath(this.player.sources, 'metadata.epgId')) {

--- a/src/ott-analytics.js
+++ b/src/ott-analytics.js
@@ -255,7 +255,11 @@ class OttAnalytics extends BasePlugin {
         : this.config.entryId,
       position: this._getPosition()
     };
-    if (eventParams.mediaType === 'RECORDING' || eventParams.contextType === 'CATCHUP' || eventParams.contextTyp === 'START_OVER') {
+    if (
+      eventParams.mediaType.toUpperCase() === 'RECORDING' ||
+      eventParams.contextType.toUpperCase() === 'CATCHUP' ||
+      eventParams.contextType.toUpperCase() === 'START_OVER'
+    ) {
       eventParams.programId = eventParams.mediaId;
     } else if (Utils.Object.hasPropertyPath(this.player.sources, 'metadata.epgId')) {
       eventParams.programId = this.player.sources.metadata.epgId;

--- a/src/ott-analytics.js
+++ b/src/ott-analytics.js
@@ -1,5 +1,5 @@
 //@flow
-import {core, BasePlugin, providers} from 'kaltura-player-js';
+import {core, BasePlugin} from 'kaltura-player-js';
 import {OTTBookmarkService, RequestBuilder} from 'playkit-js-providers/dist/playkit-bookmark-service';
 
 type OttAnalyticsEventType = {[event: string]: string};
@@ -255,11 +255,7 @@ class OttAnalytics extends BasePlugin {
         : this.config.entryId,
       position: this._getPosition()
     };
-    if (
-      eventParams.mediaType === providers.MediaType.RECORDING ||
-      eventParams.contextType === providers.ContextType.CATCHUP ||
-      eventParams.contextTyp === providers.ContextType.START_OVER
-    ) {
+    if (eventParams.mediaType === 'RECORDING' || eventParams.contextType === 'CATCHUP' || eventParams.contextTyp === 'START_OVER') {
       eventParams.programId = eventParams.mediaId;
     } else if (Utils.Object.hasPropertyPath(this.player.sources, 'metadata.epgId')) {
       eventParams.programId = this.player.sources.metadata.epgId;


### PR DESCRIPTION
### Description of the Changes

FEC-12773 - Send mediaId instead of epgId in bookmark event

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
